### PR TITLE
Disregard events if it is not a move for pan/pinch

### DIFF
--- a/source/SkiaScene/SkiaScene.TouchManipulation/SceneGestureRenderingResponder.cs
+++ b/source/SkiaScene/SkiaScene.TouchManipulation/SceneGestureRenderingResponder.cs
@@ -28,13 +28,14 @@ namespace SkiaScene.TouchManipulation
             {
                 _maxFramesPerSecond = value;
                 _minGestureDuration = TimeSpan.FromMilliseconds(1000d / _maxFramesPerSecond);
-
             }
         }
 
         protected override void TouchGestureRecognizerOnPan(object sender, PanEventArgs args)
         {
-            base.TouchGestureRecognizerOnPan(sender, args);
+            if (args.TouchActionType == TouchActionType.Moved)
+                base.TouchGestureRecognizerOnPan(sender, args);
+
             if (args.TouchActionType == TouchActionType.Released)
             {
                 _invalidateViewAction();
@@ -44,7 +45,9 @@ namespace SkiaScene.TouchManipulation
 
         protected override void TouchGestureRecognizerOnPinch(object sender, PinchEventArgs args)
         {
-            base.TouchGestureRecognizerOnPinch(sender, args);
+            if (args.TouchActionType == TouchActionType.Moved)
+                base.TouchGestureRecognizerOnPinch(sender, args);
+
             ProcessGestureDelays(ref _lastPinchTime, _minGestureDuration, args.TouchActionType);
         }
 

--- a/source/SkiaScene/SkiaScene.TouchManipulation/SceneGestureRenderingResponder.cs
+++ b/source/SkiaScene/SkiaScene.TouchManipulation/SceneGestureRenderingResponder.cs
@@ -33,8 +33,7 @@ namespace SkiaScene.TouchManipulation
 
         protected override void TouchGestureRecognizerOnPan(object sender, PanEventArgs args)
         {
-            if (args.TouchActionType == TouchActionType.Moved)
-                base.TouchGestureRecognizerOnPan(sender, args);
+            base.TouchGestureRecognizerOnPan(sender, args);
 
             if (args.TouchActionType == TouchActionType.Released)
             {
@@ -45,8 +44,7 @@ namespace SkiaScene.TouchManipulation
 
         protected override void TouchGestureRecognizerOnPinch(object sender, PinchEventArgs args)
         {
-            if (args.TouchActionType == TouchActionType.Moved)
-                base.TouchGestureRecognizerOnPinch(sender, args);
+            base.TouchGestureRecognizerOnPinch(sender, args);
 
             ProcessGestureDelays(ref _lastPinchTime, _minGestureDuration, args.TouchActionType);
         }

--- a/source/SkiaScene/SkiaScene.TouchManipulation/SceneGestureResponder.cs
+++ b/source/SkiaScene/SkiaScene.TouchManipulation/SceneGestureResponder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using SkiaSharp;
+using TouchTracking;
 
 namespace SkiaScene.TouchManipulation
 {
@@ -34,6 +35,9 @@ namespace SkiaScene.TouchManipulation
 
         protected virtual void TouchGestureRecognizerOnPinch(object sender, PinchEventArgs args)
         {
+            if (args.TouchActionType != TouchActionType.Moved)
+                return;
+
             var previousPoint = args.PreviousPoint;
             var newPoint = args.NewPoint;
             var pivotPoint = args.PivotPoint;
@@ -80,6 +84,9 @@ namespace SkiaScene.TouchManipulation
 
         protected virtual void TouchGestureRecognizerOnPan(object sender, PanEventArgs args)
         {
+            if (args.TouchActionType != TouchActionType.Moved)
+                return;
+
             SKPoint resultVector = args.NewPoint - args.PreviousPoint;
             _skScene.MoveByVector(resultVector);
         }


### PR DESCRIPTION
If you tap the Skia Canvas on some Android devices, it will move the canvas by 1 point.

This partially fixes #19 
