### PR TITLE
fix app crashes on Android

### DIFF
--- a/source/TouchTracking/TouchTracking.Droid/TouchHandler.cs
+++ b/source/TouchTracking/TouchTracking.Droid/TouchHandler.cs
@@ -1,4 +1,4 @@
-﻿using Android.Views;
+using Android.Views;
 using System;
 using System.Collections.Generic;
 
@@ -105,7 +105,10 @@ namespace TouchTracking.Droid
                 case MotionEventActions.PointerDown:
                     FireEvent(this, id, TouchActionType.Pressed, screenPointerCoords, true);
 
+                    if (!_idToTouchHandlerDictionary.ContainsKey(id))
+                    {
                     _idToTouchHandlerDictionary.Add(id, this);
+                    }
 
                     _capture = Capture;
 


### PR DESCRIPTION
In some rare circustance, when lot's of fingers are dedected, Android might not report all release events, leading to re-adding ids to the dictionary, causing the app to crash.

workaround for #25 